### PR TITLE
only_llm_result

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,4 +1,10 @@
 {
+    "only_llm_result": {
+        "description": "只处理LLM结果",
+        "type": "bool",
+        "hint": "只处理 LLM返回的消息。建议打开",
+        "default": true
+    },
     "format": {
         "description": "转化的语音的格式",
         "type": "string",

--- a/main.py
+++ b/main.py
@@ -155,17 +155,20 @@ class RecordConverterPlugin(Star):
     @filter.on_decorating_result()
     async def on_decorating_result(self, event: AiocqhttpMessageEvent):
         """将文本按概率生成语音并发送"""
-        # 概率控制
-        if random.random() > self.conf["record"]["record_prob"]:
-            return
         result = event.get_result()
         if not result:
             return
         chain = result.chain
         if not chain:
             return
-        seg = chain[0]
+        # 仅处理LLM消息
+        if self.conf["only_llm_result"] and not result.is_llm_result():
+            return
+        # 概率控制
+        if random.random() > self.conf["record"]["record_prob"]:
+            return
 
+        seg = chain[0]
         # 纯短文本
         if (
             len(chain) == 1


### PR DESCRIPTION
## Summary by Sourcery

根据配置，将语音生成限定为仅对由 LLM 生成的结果生效，并相应更新配置模式（schema）。

新功能：
- 新增选项，可将语音生成限制为仅针对由 LLM 派生的消息结果。

增强：
- 重新排序语音生成检查逻辑，使 LLM 来源过滤在概率采样之前执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate voice generation on LLM-originated results based on configuration and update configuration schema accordingly.

New Features:
- Add an option to restrict voice generation to only LLM-derived message results.

Enhancements:
- Reorder voice generation checks so that LLM-origin filtering occurs before probabilistic sampling.

</details>